### PR TITLE
cleanup-after-each is no longer necessary!

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -191,8 +191,6 @@ Similar to `enzyme` you can create a `src/setupTests.js` file to avoid boilerpla
 
 ```js
 // react-testing-library renders your components to document.body,
-// this will ensure they're removed after each test.
-import '@testing-library/react/cleanup-after-each';
 // this adds jest-dom's custom assertions
 import '@testing-library/jest-dom/extend-expect';
 ```


### PR DESCRIPTION
cleanup is called now by default after each test if the testing framework supports the afterEach global!

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
